### PR TITLE
Merge client and server into single container

### DIFF
--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -1,0 +1,29 @@
+FROM node:20-alpine AS base
+
+WORKDIR /app
+
+ENV MONGO_ENDPOINT=mongodb://mongo:27017/your_spotify
+
+RUN apk add python3 gcc g++ make cmake && npm install -g nodemon
+
+COPY yarn.lock package.json ./
+COPY apps/dev/package.json apps/dev/package.json
+COPY apps/dev/tsconfig.json apps/dev/tsconfig.json
+COPY apps/server/package.json apps/server/package.json
+COPY apps/server/tsconfig.json apps/server/tsconfig.json
+COPY apps/client/package.json apps/client/package.json
+COPY apps/client/tsconfig.json apps/client/tsconfig.json
+
+RUN yarn --frozen-lockfile
+
+COPY apps/server/src apps/server/src
+COPY apps/server/scripts apps/server/scripts
+COPY apps/client/public apps/client/public
+COPY apps/client/src apps/client/src
+COPY apps/client/scripts apps/client/scripts
+COPY full-entrypoint.sh /app/full-entrypoint.sh
+
+ARG NODE_ENV
+ENV NODE_ENV ${NODE_ENV:-development}
+
+ENTRYPOINT ["sh", "/app/full-entrypoint.sh"]

--- a/Dockerfile.full.production
+++ b/Dockerfile.full.production
@@ -1,0 +1,53 @@
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+ENV MONGO_ENDPOINT=mongodb://mongo:27017/your_spotify
+
+RUN apk add python3 gcc g++ make cmake
+
+COPY yarn.lock package.json ./
+COPY apps/dev/package.json apps/dev/package.json
+COPY apps/dev/tsconfig.json apps/dev/tsconfig.json
+COPY apps/server/package.json apps/server/package.json
+COPY apps/server/tsconfig.json apps/server/tsconfig.json
+COPY apps/client/package.json apps/client/package.json
+COPY apps/client/tsconfig.json apps/client/tsconfig.json
+
+RUN yarn --frozen-lockfile --network-timeout 500000
+
+COPY apps/server/src apps/server/src
+COPY apps/server/scripts apps/server/scripts
+COPY apps/client/public apps/client/public
+COPY apps/client/src apps/client/src
+COPY apps/client/scripts apps/client/scripts
+
+WORKDIR /app/apps/client
+RUN yarn build
+WORKDIR /app/apps/server
+RUN yarn build
+
+ARG NODE_ENV
+ENV NODE_ENV ${NODE_ENV:-production}
+
+RUN rm -r /app/node_modules && yarn --production --frozen-lockfile
+
+FROM node:20-alpine
+
+ARG NODE_ENV
+ENV NODE_ENV ${NODE_ENV:-production}
+
+WORKDIR /app
+
+RUN apk add python3 gcc g++ make cmake && npm install -g serve
+
+COPY --from=builder /app/node_modules node_modules
+COPY --from=builder /app/package.json package.json
+COPY --from=builder /app/apps/server/package.json apps/server/package.json
+COPY --from=builder /app/apps/server/scripts/ apps/server/scripts/
+COPY --from=builder /app/apps/server/lib/ apps/server/lib/
+COPY --from=builder /app/apps/client/build/ apps/client/build/
+COPY --from=builder /app/apps/client/scripts/ apps/client/scripts/
+COPY full-entrypoint.sh /app/full-entrypoint.sh
+
+ENTRYPOINT ["sh", "/app/full-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -46,11 +46,14 @@ Follow the [docker-compose-example.yml](https://github.com/Yooooomi/your_spotify
 
 ```yml
 services:
-  server:
-    image: yooooomi/your_spotify_server
+  your_spotify:
+    build:
+      context: .
+      dockerfile: Dockerfile.full.production
     restart: always
     ports:
       - "8080:8080"
+      - "3000:3000"
     links:
       - mongo
     depends_on:
@@ -65,14 +68,6 @@ services:
     image: mongo:6
     volumes:
       - ./your_spotify_db:/data/db
-
-  web:
-    image: yooooomi/your_spotify_client
-    restart: always
-    ports:
-      - "3000:3000"
-    environment:
-      API_ENDPOINT: http://localhost:8080
 ```
 
 > Some ARM-based devices might have trouble with Mongo >= 5. I suggest you use the image **mongo:4.4**.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ You can follow the instructions [here](https://github.com/Yooooomi/your_spotify/
 | PROMETHEUS_USERNAME             | _not defined_ | Prometheus basic auth username (see [here](https://github.com/Yooooomi/your_spotify/tree/master/apps/server#prometheus)) |
 | PROMETHEUS_PASSWORD             | _not defined_ | Prometheus basic auth password |
 | LOG_LEVEL             | info | The log level, debug is useful if you encouter any bugs |
-| CORS                  | _not defined_ | List of comma-separated origin allowed (not required; defaults to CLIENT_ENDPOINT) |
+| CORS                  | _not defined_ | List of comma-separated origin allowed (not required; defaults to CLIENT_ENDPOINT). These origins will also be added to the frontend CSP `connect-src` directive |
 | COOKIE_VALIDITY_MS    | 1h | Validity time of the authentication cookie, following [this pattern](https://github.com/vercel/ms) |
 | MAX_IMPORT_CACHE_SIZE | Infinite | The maximum element in the cache when importing data from an outside source, more cache means less requests to Spotify, resulting in faster imports |
 | MONGO_NO_ADMIN_RIGHTS | false | Do not ask for admin right on the Mongo database |
@@ -102,7 +102,7 @@ You can follow the instructions [here](https://github.com/Yooooomi/your_spotify/
 99.9% of users do not need to worry about this, it is handled automatically.
 
 If your use case requires the backend to be used from multiple frontend origins, you can manually adjust the `CORS` variable.
-For example, a value of `origin1,origin2` will allow `origin1` and `origin2`.
+For example, a value of `origin1,origin2` will allow `origin1` and `origin2`. These origins are also added to the web client's `connect-src` policy so it can reach the API from any of them.
 
 # Creating the Spotify Application
 

--- a/apps/client/scripts/run/variables.sh
+++ b/apps/client/scripts/run/variables.sh
@@ -35,6 +35,22 @@ then
     CSP_CONNECT_SRC="$CSP_CONNECT_SRC/"
 fi
 
+# Allow additional hosts specified in CORS for local access
+if [[ -n "$CORS" && "$CSP_CONNECT_SRC" != "*" ]]
+then
+    for host in ${CORS//,/ }
+    do
+        if [[ "$host" != "$API_ENDPOINT" ]]
+        then
+            if ! echo "$host" | grep -q "/$"
+            then
+                host="$host/"
+            fi
+            CSP_CONNECT_SRC="$CSP_CONNECT_SRC $host"
+        fi
+    done
+fi
+
 sed -i "s#connect-src \(.*\);#connect-src 'self' $CSP_CONNECT_SRC;#g" "$VAR_PATH/index.html"
 
 # Handling frame-ancestors preferences

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,20 +1,23 @@
 services:
   app:
-    container_name: server
+    container_name: your_spotify
     restart: always
     build:
       context: .
-      dockerfile: Dockerfile.server
+      dockerfile: Dockerfile.full
       args:
         NODE_ENV: development
     volumes:
       - ./apps/server/src/:/app/apps/server/src/
+      - ./apps/client/src:/app/apps/client/src/
+      - ./apps/client/public:/app/apps/client/public/
     links:
       - mongo
     depends_on:
       - mongo
     ports:
       - "8080:8080"
+      - "3000:3000"
     environment:
       LOG_LEVEL: debug
       API_ENDPOINT: http://localhost:8080 # This MUST be included as a valid URL in the spotify dashboard
@@ -29,20 +32,3 @@ services:
       - ./db_data:/data/db
     ports:
       - "27017:27017"
-
-  web:
-    container_name: web
-    restart: always
-    build:
-      context: .
-      dockerfile: Dockerfile.client
-      args:
-        NODE_ENV: development
-    volumes:
-      - ./apps/client/src:/app/apps/client/src/
-      - ./apps/client/public:/app/apps/client/public/
-    ports:
-      - "3000:3000"
-    environment:
-      NODE_ENV: development
-      API_ENDPOINT: http://localhost:8080

--- a/docker-compose-example.yml
+++ b/docker-compose-example.yml
@@ -1,9 +1,12 @@
 services:
-  server:
-    image: yooooomi/your_spotify_server
+  your_spotify:
+    build:
+      context: .
+      dockerfile: Dockerfile.full.production
     restart: always
     ports:
       - "8080:8080"
+      - "3000:3000"
     links:
       - mongo
     depends_on:
@@ -20,11 +23,3 @@ services:
     restart: always
     volumes:
       - ./your_spotify_db:/data/db
-
-  web:
-    image: yooooomi/your_spotify_client
-    restart: always
-    ports:
-      - "3000:3000"
-    environment:
-      API_ENDPOINT: http://localhost:8080

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,10 +1,10 @@
 services:
   app:
-    container_name: server
+    container_name: your_spotify
     restart: always
     build:
       context: .
-      dockerfile: Dockerfile.server.production
+      dockerfile: Dockerfile.full.production
       args:
         NODE_ENV: production
     links:
@@ -13,6 +13,7 @@ services:
       - mongo
     ports:
       - "8080:8080"
+      - "3000:3000"
     environment:
       LOG_LEVEL: debug
       API_ENDPOINT: http://localhost:8080 # This MUST be included as a valid URL in the spotify dashboard
@@ -27,17 +28,3 @@ services:
       - ./db_data:/data/db
     ports:
       - "27017:27017"
-
-  web:
-    container_name: web
-    restart: always
-    build:
-      context: .
-      dockerfile: Dockerfile.client.production
-      args:
-        NODE_ENV: production
-    ports:
-      - "3000:3000"
-    environment:
-      NODE_ENV: production
-      API_ENDPOINT: http://localhost:8080

--- a/full-entrypoint.sh
+++ b/full-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+if [ "$NODE_ENV" = "development" ]; then
+  /app/apps/server/scripts/run/run_dev.sh &
+  SERVER_PID=$!
+  /app/apps/client/scripts/run/run_dev.sh &
+  CLIENT_PID=$!
+else
+  /app/apps/server/scripts/run/run.sh &
+  SERVER_PID=$!
+  /app/apps/client/scripts/run/run.sh &
+  CLIENT_PID=$!
+fi
+
+trap 'kill $SERVER_PID $CLIENT_PID' INT TERM
+wait $SERVER_PID $CLIENT_PID


### PR DESCRIPTION
## Summary
- build a single container for server and client with `Dockerfile.full*`
- run both apps from one entrypoint script
- update docker-compose files for the new container
- document the new setup in the README

## Testing
- `yarn --cwd apps/server lint` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6884c8c2f324832685a2af01e217ed59