### PR TITLE
Fix nightly GHCR push

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,6 +14,10 @@ on:
       - master
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/Dockerfile.client.production
+++ b/Dockerfile.client.production
@@ -24,7 +24,7 @@ WORKDIR /app/apps/client
 RUN yarn build
 
 ARG NODE_ENV
-ENV NODE_ENV ${NODE_ENV:-production}
+ENV NODE_ENV=${NODE_ENV:-production}
 
 FROM node:20-alpine
 


### PR DESCRIPTION
## Summary
- grant contents read along with package write permission

## Testing
- `yarn workspaces foreach -A run test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6884e83d53388326878cf8ae07f11091